### PR TITLE
Clarifying the template's intent

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -7,22 +7,40 @@ assignees: ''
 
 ---
 
+<!--
+This is for listed meetings on the https://comm-comm.datproject.org.
+To be listed this issue needs to have two things:
+
+1. a **correct** time 
+2. an **assigned** organizer
+
+Change the meeting time below!
+
+Example: 04 Nov 2020, 13:40 Asia/Tokyo
+Valid Timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+-->
+
+:alarm_clock: Time: DD MMM YYYY, hh:mm GMT
+
+<!-- Everything after this is a suggestion, you may change what suits to you! -->
+
 Just an hour hanging out and talking about DAT stuff.
 
 :point_right: **Post a comment in this github issue with any topics you'd like to cover this week**
 
-:alarm_clock: Time: DD MMM YYYY, hh:mm GMT
-
-:link: https://zoom.us/j/181036238 (Native)
+:link: https://zoom.us/j/181036238 (Native)<br/>
 :link: https://zoom.us/wc/join/181036238?pwd= (Web)
 
-| Timezone      |  Date/Time           |
+
+<!-- If you use this template, don't forget to update the Meeting times below (also in the link!) -->
+
+| Timezone      |  Date/Time    |
 | ------------- |:-------------:|
 | Buenos Aires  | DD MMM, hh PM |
-| Toronto       | DD MMM, hh PM      |
-| New York      | DD MMM, hh PM      |
-| Los Angeles   | DD MMM, hh AM      |
-| Berlin        | DD MMM, hh PM      |
+| Toronto       | DD MMM, hh PM |
+| New York      | DD MMM, hh PM |
+| Los Angeles   | DD MMM, hh AM |
+| Berlin        | DD MMM, hh PM |
 
 Or in your local time: https://www.timeanddate.com/worldclock/fixedtime.html?msg=Dat+Comm-Comm+Meeting+YYYY-MM-DD&iso=YYYYMMDDT18&p1=1440&ah=1
 

--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -32,9 +32,7 @@ Just an hour hanging out and talking about DAT stuff.
 
 :link: https://zoom.us/j/181036238 (Native)<br/>
 :link: https://zoom.us/wc/join/181036238?pwd= (Web)
-
 <!-- :link: https://talky.io/dat-comm-comm (Web) -->
-
 <!-- :link: https://meet.jit.si/dat-comm-comm (Web) -->
 
 <!-- If you use this template, don't forget to update the Meeting times below (also in the link!) -->

--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -28,9 +28,14 @@ Just an hour hanging out and talking about DAT stuff.
 
 :point_right: **Post a comment in this github issue with any topics you'd like to cover this week**
 
+<!-- Choose the hangout you'd like to use (or add the one of your choice). Use only one and comment out the others -->
+
 :link: https://zoom.us/j/181036238 (Native)<br/>
 :link: https://zoom.us/wc/join/181036238?pwd= (Web)
 
+<!-- :link: https://talky.io/dat-comm-comm (Web) -->
+
+<!-- :link: https://meet.jit.si/dat-comm-comm (Web) -->
 
 <!-- If you use this template, don't forget to update the Meeting times below (also in the link!) -->
 


### PR DESCRIPTION
Clarifying the optional and required parts of the template to be listed as an event on the homepage and in the calendar.
Also making sure that organizers know how to use the template.